### PR TITLE
CR guide - remove commits convention

### DIFF
--- a/src/content/code-review.mdx
+++ b/src/content/code-review.mdx
@@ -66,11 +66,6 @@ DO: „tests for input component”, „select added to storybook”, „modal -
 DON’T: „fixes”, „CR fixes”, „link” - they are not meaningful, „general UI components” - sounds like there are many things inside like a few components
 
 
-## Commits convention
-Commits should be written with a similar convention as used in titles and branches. It means commits should look like: XX-YYY - Lorem ipsum dolor,
-e.g. MEC-100 - tests for input component
-
-
 ## Force-pushing - do or don’t?
 If your PR is in the code review process it’s not good to force-push on it. Remember it’s a change of commits history. You are not obligated to forget about force-pushing, but use it only on private branches that were not yet reviewed. Otherwise it breaks the tracking mechanism and may lead to review duplication.
 


### PR DESCRIPTION
**Description**
Commits convention removed as we discussed on #frontend

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>

**Self check**

- [x] Self CR'd
- [ ] Tests included
- [x] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**
