### PR TITLE
Added subsection to the Code section about avoid destructuring props

### DIFF
--- a/src/content/styleguide.mdx
+++ b/src/content/styleguide.mdx
@@ -256,7 +256,7 @@ const MyComponent: AppFunctionComponent<Props> = ({ property, optionalProperty =
 
 ## Avoid destructuring props if it isn't needed
 
-Try to keep it as simple as possible passing props. Avoid destructuring props if you can pass whole props or part of props by use the rest operator.
+Try to keep passing props as simple as possible. Avoid destructurization if you can pass the whole object or part of it by using the rest operator.
 
 ### Example
 

--- a/src/content/styleguide.mdx
+++ b/src/content/styleguide.mdx
@@ -254,6 +254,33 @@ const MyComponent: AppFunctionComponent<Props> = ({ property, optionalProperty =
 }
 ```
 
+## Avoid destructuring props if it isn't needed
+
+Try to keep it as simple as possible passing props. Avoid destructuring props if you can pass whole props or part of props by use the rest operator.
+
+### Example
+
+```tsx
+// Good.
+const MyComponent: AppFunctionComponent<Props> = (props) => {
+  return <div {...props} />
+}
+
+const MyComponent: AppFunctionComponent<Props> = ({ otherProperty, ...props }) => {
+  return (
+    <div otherProperty={otherProperty}>
+      <div {...props} />
+    </div>
+  )
+}
+
+// Bad.
+const MyComponent: AppFunctionComponent<Props> = ({ otherProperty, ...props }) => {
+  return <div otherProperty={otherProperty} {...props} />
+}
+```
+
+
 ## Prrefer explicit return over arrow return in components
 
 Arrow returns tend to create massive diffs when a code that needs to be outside of the initial return statement is added to the component. Avoid this scenario by always using curly braces with the explicit return.


### PR DESCRIPTION
Jira: [YY-XXX]

**Description**
I added a subsection about avoiding destructuring props when it isn't needed. Very often you may see in some projects biding a single prop to elements. For example, It's could be the result of a willingness to show off props structure (somebody says that is a good practice in a project without TS) or the refactoring where destructing props isn't needed farther.

⚠️ I added `tsx` extension to the code block. I'm not sure that it will be work. I noticed that the project is using the typescript lang. I can't find any list of lang list supports.

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>

**Self check**

- [x] Self CR'd
- [ ] Tests included
- [x] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**
