### PR TITLE
CR guide update: 'in QA' label, comment colors

### DIFF
--- a/src/content/code-review.mdx
+++ b/src/content/code-review.mdx
@@ -100,7 +100,7 @@ Remember about a team goal :)
 To make your comments more clear, it will be great to use some colorful icons which will indicate a criticality level.
 - [no color] - something to remember in the future, a question, request for explanation, memes. This comment is not important and doesn't have impact in a review (not a blocker, not an accept).
 - 🟩 - code changes suggestions, small fixes of namings, interpunction, which doesn't have large impact in code quality. These comments can be skipped by a PR's author. Author can resolve those comments.
-- [yellow] - potentially important problems, which has an impact in maintenance, tests, or can cause a technical debt. These comments should be covered by a fix, a discussion or a JIRA task with next steps. This comment can be resolved by it's author only. If a 'yellow' comment is added while 'in QA' label is pinned, PR's author can decide about it.
+- 🟨 - potentially important problems, which has an impact in maintenance, tests, or can cause a technical debt. These comments should be covered by a fix, a discussion or a JIRA task with next steps. This comment can be resolved by it's author only. If a 'yellow' comment is added while 'in QA' label is pinned, PR's author can decide about it.
 - [red] - a code bug, which needs to be fixed. It's an absolute blocker and should be fixed, even if a 'in QA' label is pinned.
 
 

--- a/src/content/code-review.mdx
+++ b/src/content/code-review.mdx
@@ -97,7 +97,11 @@ Remember about a team goal :)
 ## Comments from reviewers
 
 ### How to be a good reviewer?
-[TBA]
+To make your comments more clear, it will be great to use some colorful icons which will indicate a criticality level.
+- [no color] - something to remember in the future, a question, request for explanation, memes. This comment is not important and doesn't have impact in a review (not a blocker, not an accept).
+- [green] - code changes suggestions, small fixes of namings, interpunction, which doesn't have large impact in code quality. These comments can be skipped by a PR's author. Author can resolve those comments.
+- [yellow] - potentially important problems, which has an impact in maintenance, tests, or can cause a technical debt. These comments should be covered by a fix, a discussion or a JIRA task with next steps. This comment can be resolved by it's author only. If a 'yellow' comment is added while 'in QA' label is pinned, PR's author can decide about it.
+- [red] - a code bug, which needs to be fixed. It's an absolute blocker and should be fixed, even if a 'in QA' label is pinned.
 
 
 ### Should I change everything that was requested?
@@ -129,11 +133,12 @@ If all fixes are done remember to request a re-review from a reviewer. You shoul
 # FAQ
 
 ## Labels - should I use them?
-We usually don’t use labels, because all labels stuff we are organising with currently available tools:
+We usually don’t use labels, because almost all labels stuff we are organising with currently available tools:
 - „work in progress” - draft PR
 - „blocked” - changes requested / draft PR / description
 - „ready for CR” - request somebody a CR with ![Re-review](/code-review-guide/re-review-icon.png)
-- „in QA” - can be marked in self checks
+
+You should use a label „in QA” when code review process is finished and a task is in QA. When you add this label, new comments can be skipped (if mentioned issues are not critical).
 
 
 ## What is more important - preparing a new PR or code reviewing?

--- a/src/content/code-review.mdx
+++ b/src/content/code-review.mdx
@@ -99,7 +99,7 @@ Remember about a team goal :)
 ### How to be a good reviewer?
 To make your comments more clear, it will be great to use some colorful icons which will indicate a criticality level.
 - [no color] - something to remember in the future, a question, request for explanation, memes. This comment is not important and doesn't have impact in a review (not a blocker, not an accept).
-- [green] - code changes suggestions, small fixes of namings, interpunction, which doesn't have large impact in code quality. These comments can be skipped by a PR's author. Author can resolve those comments.
+- 🟩 - code changes suggestions, small fixes of namings, interpunction, which doesn't have large impact in code quality. These comments can be skipped by a PR's author. Author can resolve those comments.
 - [yellow] - potentially important problems, which has an impact in maintenance, tests, or can cause a technical debt. These comments should be covered by a fix, a discussion or a JIRA task with next steps. This comment can be resolved by it's author only. If a 'yellow' comment is added while 'in QA' label is pinned, PR's author can decide about it.
 - [red] - a code bug, which needs to be fixed. It's an absolute blocker and should be fixed, even if a 'in QA' label is pinned.
 

--- a/src/content/code-review.mdx
+++ b/src/content/code-review.mdx
@@ -101,7 +101,7 @@ To make your comments more clear, it will be great to use some colorful icons wh
 - [no color] - something to remember in the future, a question, request for explanation, memes. This comment is not important and doesn't have impact in a review (not a blocker, not an accept).
 - 🟩 - code changes suggestions, small fixes of namings, interpunction, which doesn't have large impact in code quality. These comments can be skipped by a PR's author. Author can resolve those comments.
 - 🟨 - potentially important problems, which has an impact in maintenance, tests, or can cause a technical debt. These comments should be covered by a fix, a discussion or a JIRA task with next steps. This comment can be resolved by it's author only. If a 'yellow' comment is added while 'in QA' label is pinned, PR's author can decide about it.
-- [red] - a code bug, which needs to be fixed. It's an absolute blocker and should be fixed, even if a 'in QA' label is pinned.
+- 🟥 - a code bug, which needs to be fixed. It's an absolute blocker and should be fixed, even if a 'in QA' label is pinned.
 
 
 ### Should I change everything that was requested?


### PR DESCRIPTION
Jira: -

**Description**
Last decisions about code review improvements are mentioned here:
- using 'in QA' label in your PRs
- using colors in your CR comments to make it more actionable 🚀 

**Self check**

- [x] Self CR'd
- [ ] Tests included
- [ ] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**
